### PR TITLE
Add packages in order to build lua-zlib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
 FROM kong:latest
 USER root
+RUN apt-get update && apt-get install -y \
+    gcc \
+    zlib1g-dev \
+    make \
+    unzip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 RUN luarocks install --server=http://luarocks.org/manifests/moesif kong-plugin-moesif
 USER kong


### PR DESCRIPTION
Solves issues I was having running the container which required lua-zlib to be installed to install the Moesif Kong plugin. 